### PR TITLE
Add on_post_page event to monitor file generation

### DIFF
--- a/mkdocs_plugin_progress/__init__.py
+++ b/mkdocs_plugin_progress/__init__.py
@@ -26,6 +26,9 @@ class Progress(BasePlugin):
     def on_post_build(self, *args, **kwargs):
         _info("Finishing up...")
 
+    def on_post_page(self, *args, **kwargs):
+        _info("Writing file \"{}\"...".format(kwargs["page"].file.src_path.replace(".md", ".html")))
+
     def on_template_context(self, *args, **kwargs):
         _info("Contextualized template {}.".format(kwargs["template_name"]))
         return None

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ URLs = \
 
 setuptools.setup(
     name="mkdocs-plugin-progress",
-    version="1.1.4",
+    version="1.1.5",
     packages=setuptools.find_packages(),
     description="A plugin for MkDocs that lets you know exactly what is happening during the build.",
     keywords=["mkdocs", "plugin", "progress", "build", "debugging"],


### PR DESCRIPTION
Currently, the plugin uses `on_page_read_source` to monitor the processing of the MD files.

It would be useful to also be able to monitor when each HTML file is written to disk. This can be achieved by adding the `on_post_page` event.